### PR TITLE
Allow use of forked JMusicBot repositories

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,8 @@ RUN install_packages openjdk-11-jre-headless wget curl grep \
 
 STOPSIGNAL SIGTERM
 
-ENV BOT_VERSION latest
-ENV BOT_GITHUB "jagrosh/MusicBot"
+ENV BOT_VERSION="latest"
+ENV BOT_GITHUB="jagrosh/MusicBot"
 
 COPY run_bot.sh /app/run_bot.sh
 RUN chmod +x /app/run_bot.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN install_packages openjdk-11-jre-headless wget curl grep \
 STOPSIGNAL SIGTERM
 
 ENV BOT_VERSION latest
+ENV BOT_GITHUB "jagrosh/MusicBot"
 
 COPY run_bot.sh /app/run_bot.sh
 RUN chmod +x /app/run_bot.sh

--- a/README.md
+++ b/README.md
@@ -9,7 +9,11 @@ A simple Docker container for [JMusicBot](https://github.com/jagrosh/MusicBot). 
 - Place your **config.txt**, **Playlists** folder, and **serversettings.json** file (if you have one) in `/your/path/to/config`. This directory will be shared with the container.
   > Refer to the documentaion on how to [configure the bot](https://jmusicbot.com/setup/#3-configure-the-bot)
 - You can specify a JMusicBot version using the environment variable `BOT_VERSION`. By default the latest version will be downloaded so you don't have to include the value if you want to use latest.
-  > The version numbers you can use correspond to the [releases](https://github.com/jagrosh/MusicBot/releases)
+  > The version numbers you can use correspond to the [releases](https://github.com/jagrosh/MusicBot/releases) tag, not the release name.
+- Optionally, specify a JMusicBot repository to use by the environment variable `BOT_GITHUB`. This is ideal for using forks of the main repo when something breaks, and no fixes are yet available. It is recommended to set `updatealerts=false` in the bot config when using this option. By default this will be the official repository, `jagrosh/MusicBot`.
+  > jagrosh/MusicBot  
+    SeVile/MusicBot
+
 
 ### Docker examples
 - Using docker cli
@@ -31,6 +35,7 @@ services:
     container_name: jmusicbot
     environment:
       - BOT_VERSION=0.3.9 # You can omit the environment variable if you just want to run the latest version
+      - BOT_GITHUB=jagrosh/MusicBot # Optional. In the format {Owner}/{Repository}
     volumes:
       - /your/path/to/config:/config
     restart: unless-stopped

--- a/run_bot.sh
+++ b/run_bot.sh
@@ -10,6 +10,8 @@ fi
 # Check if the release JSON was fetched successfully
 if [ -z "$RELEASE_JSON" ] || echo "$RELEASE_JSON" | grep -q '"message": "Not Found"'; then
   echo "Error: Could not find release for version '$BOT_VERSION'."
+  echo "Possible release tags for ${BOT_GITHUB}:"
+  curl --silent "https://api.github.com/repos/${BOT_GITHUB}/releases" | grep -Po '"tag_name":\s*"\K[^"]*' | head -n 10
   exit 1
 fi
 

--- a/run_bot.sh
+++ b/run_bot.sh
@@ -17,9 +17,8 @@ VERSION_TAG=$(echo "$RELEASE_JSON" | grep -Po '"tag_name":\s*"\K[^"]*')
 ASSET_NAME=$(echo "$RELEASE_JSON" | grep -Po '"name":\s*"\KJMusicBot[^"]*\.jar')
 DOWNLOAD_URL=$(echo "$RELEASE_JSON" | grep -Po '"browser_download_url":\s*"\Khttps://[^"]*JMusicBot[^"]*\.jar')
 
-echo -e "Using JMusicBot $VERSION_TAG"
+echo -e "Downloading JMusicBot $VERSION_TAG"
 if [ ! -f "$ASSET_NAME" ]; then
-  echo -e "Downloading JMusicBot $VERSION_TAG"
   wget "$DOWNLOAD_URL" -O "$ASSET_NAME"
 fi
 

--- a/run_bot.sh
+++ b/run_bot.sh
@@ -1,17 +1,20 @@
 #!/bin/bash
 
-# Set the default version to latest
-VER_DEFAULT=$(curl --silent "https://api.github.com/repos/jagrosh/MusicBot/releases/latest" | grep -Po '"tag_name": "\K.*?(?=")')
+RELEASE_JSON=$(curl --silent "https://api.github.com/repos/${BOT_GITHUB}/releases/latest")
+
+VER_DEFAULT=$(echo "$RELEASE_JSON" | grep -Po '"tag_name":\s*"\K[^"]*')
+ASSET_NAME=$(echo "$RELEASE_JSON" | grep -Po '"name":\s*"\KJMusicBot[^"]*\.jar')
+DOWNLOAD_URL=$(echo "$RELEASE_JSON" | grep -Po '"browser_download_url":\s*"\Khttps://[^"]*JMusicBot[^"]*\.jar')
 
 # If the ENV is not explicitly set, use the sourced ENV from the Dockerfile
-if [ $BOT_VERSION == "latest" ]; then
+if [ "$BOT_VERSION" == "latest" ]; then
   BOT_VERSION=$VER_DEFAULT
 fi
 
 echo -e "Downloading JMusicBot $BOT_VERSION"
-if [ ! -f JMusicBot-$BOT_VERSION.jar ]; then	
-  wget https://github.com/jagrosh/MusicBot/releases/download/$BOT_VERSION/JMusicBot-$BOT_VERSION.jar
+if [ ! -f "$ASSET_NAME" ]; then
+  wget "$DOWNLOAD_URL"
 fi
 
 echo -e "Starting JMusicBot $BOT_VERSION"
-java -Dnogui=true -Dconfig=/config/config.txt -jar JMusicBot-$BOT_VERSION.jar 
+java -Dnogui=true -Dconfig=/config/config.txt -jar "$ASSET_NAME"

--- a/run_bot.sh
+++ b/run_bot.sh
@@ -1,20 +1,26 @@
 #!/bin/bash
 
-RELEASE_JSON=$(curl --silent "https://api.github.com/repos/${BOT_GITHUB}/releases/latest")
+# Get latest or specified tag version
+if [ "$BOT_VERSION" == "latest" ]; then
+  RELEASE_JSON=$(curl --silent "https://api.github.com/repos/${BOT_GITHUB}/releases/latest")
+else
+  RELEASE_JSON=$(curl --silent "https://api.github.com/repos/${BOT_GITHUB}/releases/tags/${BOT_VERSION}")
+fi
 
-VER_DEFAULT=$(echo "$RELEASE_JSON" | grep -Po '"tag_name":\s*"\K[^"]*')
+# Check if the release JSON was fetched successfully
+if [ -z "$RELEASE_JSON" ] || echo "$RELEASE_JSON" | grep -q '"message": "Not Found"'; then
+  echo "Error: Could not find release for version '$BOT_VERSION'."
+  exit 1
+fi
+
+VERSION_TAG=$(echo "$RELEASE_JSON" | grep -Po '"tag_name":\s*"\K[^"]*')
 ASSET_NAME=$(echo "$RELEASE_JSON" | grep -Po '"name":\s*"\KJMusicBot[^"]*\.jar')
 DOWNLOAD_URL=$(echo "$RELEASE_JSON" | grep -Po '"browser_download_url":\s*"\Khttps://[^"]*JMusicBot[^"]*\.jar')
 
-# If the ENV is not explicitly set, use the sourced ENV from the Dockerfile
-if [ "$BOT_VERSION" == "latest" ]; then
-  BOT_VERSION=$VER_DEFAULT
-fi
-
-echo -e "Downloading JMusicBot $BOT_VERSION"
+echo -e "Downloading JMusicBot $VERSION_TAG"
 if [ ! -f "$ASSET_NAME" ]; then
-  wget "$DOWNLOAD_URL"
+  wget "$DOWNLOAD_URL" -O "$ASSET_NAME"
 fi
 
-echo -e "Starting JMusicBot $BOT_VERSION"
+echo -e "Starting JMusicBot $VERSION_TAG"
 java -Dnogui=true -Dconfig=/config/config.txt -jar "$ASSET_NAME"

--- a/run_bot.sh
+++ b/run_bot.sh
@@ -17,8 +17,9 @@ VERSION_TAG=$(echo "$RELEASE_JSON" | grep -Po '"tag_name":\s*"\K[^"]*')
 ASSET_NAME=$(echo "$RELEASE_JSON" | grep -Po '"name":\s*"\KJMusicBot[^"]*\.jar')
 DOWNLOAD_URL=$(echo "$RELEASE_JSON" | grep -Po '"browser_download_url":\s*"\Khttps://[^"]*JMusicBot[^"]*\.jar')
 
-echo -e "Downloading JMusicBot $VERSION_TAG"
+echo -e "Using JMusicBot $VERSION_TAG"
 if [ ! -f "$ASSET_NAME" ]; then
+  echo -e "Downloading JMusicBot $VERSION_TAG"
   wget "$DOWNLOAD_URL" -O "$ASSET_NAME"
 fi
 

--- a/run_bot.sh
+++ b/run_bot.sh
@@ -19,9 +19,17 @@ VERSION_TAG=$(echo "$RELEASE_JSON" | grep -Po '"tag_name":\s*"\K[^"]*')
 ASSET_NAME=$(echo "$RELEASE_JSON" | grep -Po '"name":\s*"\KJMusicBot[^"]*\.jar')
 DOWNLOAD_URL=$(echo "$RELEASE_JSON" | grep -Po '"browser_download_url":\s*"\Khttps://[^"]*JMusicBot[^"]*\.jar')
 
+if [ -z "$ASSET_NAME" ] || [ -z "$DOWNLOAD_URL" ]; then
+  echo "Error: No matching asset found in release $VERSION_TAG."
+  exit 1
+fi
+
 echo -e "Downloading JMusicBot $VERSION_TAG"
 if [ ! -f "$ASSET_NAME" ]; then
-  wget "$DOWNLOAD_URL" -O "$ASSET_NAME"
+  if ! wget "$DOWNLOAD_URL" -O "$ASSET_NAME"; then
+    echo "Error: Failed to download $ASSET_NAME."
+    exit 1
+  fi
 fi
 
 echo -e "Starting JMusicBot $VERSION_TAG"


### PR DESCRIPTION
Hi,

I've been using your docker container to host the music bot for a while now since it is one of the only ones that allows me to specify the version of JMusicBot I wanted to use. This was extremely useful back when it broke some feature in a release that I couldn't revert from on other containers.

This pull request introduces a new feature that enables users to specify which Git repository to pull JMusicBot from. This is a result of me wanting to use the repository mentioned in [this recent bug report](https://github.com/jagrosh/MusicBot/issues/1783) from the official repo. It has a draft pull request to fix the issue, but there is no activity suggesting it will be accepted anytime soon.

The comments on that bug report mention a [fork repository](https://github.com/SeVile/MusicBot) that does fix the issue based on changes from the draft pull request. My changes make it possible to use this fork, or any other compatible repository, by simply specifying it in the docker env vars.

It doesn't break anything for existing docker compose files or run scripts since the default repository is still the official jagrosh bot.